### PR TITLE
fix buildername; update readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,13 +12,21 @@ How to use
 ----------
 
 1. Install ``sphinx`` and ``sphinx-selenium-screenshots``
-2. Add the configuration parameters::
+2. Add ``selenium_screenshots.screener`` to the extensions in your configuration file::
+
+      extensions = [
+      # ... ,
+      'selenium_screenshots.screener',
+      # ... ,
+      ]
+
+3. Add the configuration parameters::
 
       screenshots_server_path = 'http://127.0.0.1:8080'
       screenshots_read_path = '/_static/screenshots'
       screenshots_save_path = os.path.abspath(os.path.join('.',screenshots_read_path[1:]))
 
-3. Insert screenshots into your documentation with the ``screenshot`` directive::
+4. Insert screenshots into your documentation with the ``screenshot`` directive::
 
       .. screenshot:: 
          :server_path: /path/to/a/file.html

--- a/selenium_screenshots/screener.py
+++ b/selenium_screenshots/screener.py
@@ -8,8 +8,7 @@ def setup(app):
     app.add_config_value('screenshots_logout_path', '/logout/', 'html')
     app.add_config_value('screenshots_driver', 'selenium.webdriver.PhantomJS', 'html')
 
-    if app.buildername == "html":
-        app.add_directive('screenshot', ScreenshotPageDirective)
+    app.add_directive('screenshot', ScreenshotPageDirective)
     # app.connect('doctree-resolved', process_todo_nodes)
     # app.connect('env-purge-doc', purge_todos)
 


### PR DESCRIPTION
Addresses #1 and #2 

Ran into an issue where building docs errored out because of the use of the deprecated `app.buildername`. Instead, just add the directive in any case.